### PR TITLE
change a dict comprehension to allow python 2.6 compatibility

### DIFF
--- a/src/jsoncfg/config_classes.py
+++ b/src/jsoncfg/config_classes.py
@@ -312,7 +312,7 @@ class ConfigJSONObject(ConfigNode):
                                                    len(self), self._line, self._column)
 
     def _fetch_unwrapped_value(self):
-        return {key: node._fetch_unwrapped_value() for key, node in self._dict.items()}
+        return dict((key, node._fetch_unwrapped_value()) for key, node in self._dict.items())
 
     def _insert(self, key, value):
         self._dict[key] = value


### PR DESCRIPTION
This seems to be the only thing keeping this package from python 2.6 compatibility.

I know what you're thinking...  2.6?  Unfortunately I'm currently stuck with a 2.6 environment where I'd like to use json-cfg and noticed this single change in the dict comprehension syntax was all it took to make it compatible. 

I'm hoping I won't be on 2.6 much longer but in the meantime figured I'd provide this patch. Obvoiusly theres no guarantee 2.6 compatibility wont' break again in the future.